### PR TITLE
Add `sd_product` tag to Auto-rendered Product layout

### DIFF
--- a/layouts/auto_generated_product.tpl
+++ b/layouts/auto_generated_product.tpl
@@ -8,6 +8,8 @@
 <head prefix="og: http://ogp.me/ns#">
   {% include "html-head" %}
   {% include "template-styles" %}
+
+  {% sd_product %}
 </head>
 
 {%- capture bottom_content_html -%}


### PR DESCRIPTION
Include `sd_product` tag in Auto-rendered Product layout to render out product structured data.

Closes #131 